### PR TITLE
Add hash consistency and idempotent pipeline tests

### DIFF
--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,0 +1,47 @@
+import hashlib
+import sqlite3
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Ensure repository root is on the module path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Stub moviepy to allow offline testing
+sys.modules['moviepy'] = mock.Mock()
+sys.modules['moviepy.editor'] = mock.Mock()
+
+import contradiction_clipper as cc
+
+
+def test_hash_file_consistency(tmp_path):
+    sample = b'sample video data'
+    file_path = tmp_path / 'sample.mp4'
+    file_path.write_bytes(sample)
+    first = cc.hash_file(file_path)
+    second = cc.hash_file(file_path)
+    expected = hashlib.sha256(sample).hexdigest()
+    assert first == second == expected
+
+
+def test_unique_url_constraint(tmp_path):
+    db = tmp_path / 'test.db'
+    conn = sqlite3.connect(db)
+    cc.init_db(conn)
+    cursor = conn.cursor()
+    cursor.execute(
+        'INSERT INTO videos (url, video_id, file_path, sha256, dl_timestamp) '
+        'VALUES (?, ?, ?, ?, ?)',
+        ('http://example.com/a', 'a', '/tmp/a.mp4', 'hash1', 'now'),
+    )
+    conn.commit()
+    with pytest.raises(sqlite3.IntegrityError):
+        cursor.execute(
+            'INSERT INTO videos (url, video_id, file_path, sha256, dl_timestamp) '
+            'VALUES (?, ?, ?, ?, ?)',
+            ('http://example.com/a', 'b', '/tmp/b.mp4', 'hash2', 'now'),
+        )
+        conn.commit()
+    conn.close()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -38,9 +38,10 @@ def test_process_videos_dedup(tmp_path):
     urls = ['http://example.com/video1']
     list_file = tmp_path / 'urls.txt'
     list_file.write_text('\n'.join(urls))
-    with mock.patch('contradiction_clipper.download_video', side_effect=fake_download):
+    with mock.patch('contradiction_clipper.download_video', side_effect=fake_download) as mock_dl:
         cc.process_videos(str(list_file), db_path)
         cc.process_videos(str(list_file), db_path)
+        assert mock_dl.call_count == 1
     cursor = conn.cursor()
     cursor.execute('SELECT COUNT(*) FROM videos')
     count = cursor.fetchone()[0]


### PR DESCRIPTION
## Summary
- test SHA256 hashing for stability
- ensure database rejects duplicate URLs
- verify download step is not repeated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2a6f08648331b31990f1bab763d7