### PR TITLE
Align docs with script name

### DIFF
--- a/AGENT_DEV_GUIDE.md
+++ b/AGENT_DEV_GUIDE.md
@@ -58,6 +58,21 @@ Use transactions per major step; commit only when the sub-step finishes.
 • Documentation  Update README & this guide whenever the CLI or DB schema
   changes—single source of truth.
 
+### CLI Flags
+• `--video_list`  Path to a text file of URLs to process.
+• `--embed`       Generate embeddings for transcripts.
+• `--detect`      Identify contradictions between segments.
+• `--compile`     Build a contradiction montage video.
+• `--top_n`       Number of contradictions to include when compiling.
+
+### Prerequisites
+• Python 3.x and `sqlite3` (built in)
+• `yt-dlp` for video downloads
+• `whisper.cpp` compiled binary
+• `sentence-transformers` and `transformers`
+• `torch`, `torchvision`, `torchaudio`
+• `moviepy` with FFmpeg installed
+
 ──────────────────────────────────────────────────────────────────────────────
 5. FUTURE NICE-TO-HAVES (NOT YET MANDATORY)
 ──────────────────────────────────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 2025-06-27
+- Renamed documentation and script references to `contradiction_clipper.py`.
+- Added documentation for CLI flags and prerequisites.
+- Established initial changelog.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Contradictor Clipper
+# Contradiction Clipper
 
 **A powerful, automated local tool to detect and expose contradictions across multiple video sources.**
 
 ---
 
-## 📝 What is Contradictor Detector?
+## 📝 What is Contradiction Clipper?
 
-Contradictor Detector automates the extraction of contradictory statements from multiple videos (e.g., political pundits, public figures) by:
+Contradiction Clipper automates the extraction of contradictory statements from multiple videos (e.g., political pundits, public figures) by:
 
 - Downloading videos from provided URLs.
 - Transcribing videos into timestamped segments using Whisper AI.
@@ -31,7 +31,7 @@ Contradictor Detector automates the extraction of contradictory statements from 
 **Step 1: Clone the repository**
 	
 	git clone <your_repo_url>
-	cd ContradictorClipper
+	cd ContradictionClipper
 
 **Step 2: Install Python dependencies**
 
@@ -57,7 +57,7 @@ Ensure `ffmpeg` is installed and available in your system PATH.
 
 2. Run the entire pipeline (download, transcribe, embed, detect contradictions, and compile montage):
 
-		./contradictor_detector.py --video_list urls.txt --embed --detect --compile --top_n 20
+		./contradiction_clipper.py --video_list urls.txt --embed --detect --compile --top_n 20
 
 The resulting video montage will be located in:
 

--- a/contradiction_clipper.py
+++ b/contradiction_clipper.py
@@ -278,8 +278,8 @@ def compile_contradiction_montage(db_conn, output_file='output/contradiction_mon
     logging.info(f"[i] Contradiction montage successfully created: {output_file}")
 
 def main():
-    logging.info('[i] Starting Contradictor Detector pipeline.')
-    parser = argparse.ArgumentParser(description='Contradictor Detector - Complete Pipeline')
+    logging.info('[i] Starting Contradiction Clipper pipeline.')
+    parser = argparse.ArgumentParser(description='Contradiction Clipper - Complete Pipeline')
     parser.add_argument('--video_list', help='Path to file containing YouTube video URLs (one per line)')
     parser.add_argument('--embed', action='store_true', help='Generate embeddings for transcripts.')
     parser.add_argument('--detect', action='store_true', help='Detect contradictions in transcripts.')
@@ -307,7 +307,7 @@ def main():
         compile_contradiction_montage(db_conn, top_n=args.top_n)
 
     db_conn.close()
-    logging.info("[i] Contradictor Detector pipeline completed successfully.")
+    logging.info("[i] Contradiction Clipper pipeline completed successfully.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- rename docs and messages to `contradiction_clipper.py`
- document CLI flags and prerequisites
- start `CHANGELOG.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2be61d2c8331bde538ec9b18a94f