### PR TITLE
Fix main to use DB_PATH and ensure DB dir

### DIFF
--- a/contradiction_clipper.py
+++ b/contradiction_clipper.py
@@ -288,7 +288,8 @@ def main():
 
     args = parser.parse_args()
 
-    db_conn = sqlite3.connect('db/contradictions.db')
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+    db_conn = sqlite3.connect(DB_PATH)
     init_db(db_conn)
 
     if args.video_list:


### PR DESCRIPTION
## Summary
- ensure the `db/` directory is present before connecting
- use the `DB_PATH` constant instead of a hardcoded database path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f329960a483318c8a04867d645bfa