### PR TITLE
Add graceful handling when moviepy missing

### DIFF
--- a/contradiction_clipper.py
+++ b/contradiction_clipper.py
@@ -10,10 +10,13 @@ import subprocess
 import sys
 from datetime import datetime
 
-from moviepy.editor import VideoFileClip  # pylint: disable=import-error
-from moviepy.editor import (
-    concatenate_videoclips,
-)  # pylint: disable=import-error
+try:
+    from moviepy.editor import VideoFileClip, concatenate_videoclips
+except Exception as exc:  # pylint: disable=broad-exception-caught
+    logging.error(
+        "[x] Failed to import moviepy. Please install it with 'pip install moviepy'."
+    )
+    sys.exit(1)
 
 logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
 


### PR DESCRIPTION
## Summary
- catch import errors for moviepy
- log how to install moviepy and exit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f3ba496dc83318374836d7667204f