### PR TITLE
Make MoviePy optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2025-06-28
+### Changed
+- MoviePy is now imported lazily inside `extract_clip` and `compile_contradiction_montage`.
+- Running other pipeline stages no longer requires MoviePy to be installed.
+
 ## [0.1.0] - 2025-06-27
 ### Added
 - Initial release of Contradiction Clipper.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Contradiction Clipper automates the extraction of contradictory statements from 
 - `whisper.cpp`
 - `sentence-transformers`
 - `transformers`
-- `moviepy` (with FFmpeg installed)
+- `moviepy` (with FFmpeg installed, required only for `--compile`)
 
 ### ⚙️ Installation:
 
@@ -35,7 +35,8 @@ Contradiction Clipper automates the extraction of contradictory statements from 
 
 **Step 2: Install Python dependencies**
 
-	pip install yt-dlp sentence-transformers transformers moviepy torch torchvision torchaudio
+        pip install yt-dlp sentence-transformers transformers moviepy torch torchvision torchaudio
+        # moviepy only needed when compiling montages
 
 **Step 3: Setup Whisper (optimized for CPU)**
 

--- a/contradiction_clipper.py
+++ b/contradiction_clipper.py
@@ -10,14 +10,6 @@ import subprocess
 import sys
 from datetime import datetime
 
-try:
-    from moviepy.editor import VideoFileClip, concatenate_videoclips
-except Exception as exc:  # pylint: disable=broad-exception-caught
-    logging.error(
-        "[x] Failed to import moviepy. Please install it with 'pip install moviepy'."
-    )
-    sys.exit(1)
-
 logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
 
 DB_PATH = 'db/contradictions.db'
@@ -258,6 +250,12 @@ def detect_contradictions(db_conn):
 
 def extract_clip(video_path, start_time, end_time, output_path):
     """Extract a subclip from a video file."""
+    try:
+        from moviepy.editor import VideoFileClip
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        raise ImportError(
+            "moviepy is required for extracting clips. Install it with 'pip install moviepy'."
+        ) from exc
     logging.info(
         "[i] Extracting clip: %s (%s-%ss)", video_path, start_time, end_time
     )
@@ -286,6 +284,12 @@ def compile_contradiction_montage(
 ):
     """Build a montage video showcasing top contradictions."""
     # pylint: disable=too-many-locals
+    try:
+        from moviepy.editor import VideoFileClip, concatenate_videoclips
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        raise ImportError(
+            "moviepy is required for compiling montages. Install it with 'pip install moviepy'."
+        ) from exc
     logging.info('[i] Compiling contradiction montage video.')
     cursor = db_conn.cursor()
 

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -5,7 +5,6 @@ import hashlib
 import sqlite3
 import sys
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
@@ -14,11 +13,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import contradiction_clipper as cc  # noqa: E402
 # pylint: disable=wrong-import-position
-
-
-# Stub moviepy to allow offline testing
-sys.modules["moviepy"] = mock.Mock()
-sys.modules["moviepy.editor"] = mock.Mock()
 
 
 def test_hash_file_consistency(tmp_path):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -11,9 +11,6 @@ from pathlib import Path
 # Ensure repository root is on the module path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-# Stub moviepy to avoid heavy dependency during tests
-sys.modules["moviepy"] = mock.Mock()
-sys.modules["moviepy.editor"] = mock.Mock()
 
 
 import contradiction_clipper as cc  # noqa: E402


### PR DESCRIPTION
## Summary
- remove global MoviePy import
- import VideoFileClip and concatenate_videoclips inside helper functions
- update tests for lazy MoviePy import
- document optional MoviePy usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f42d177508331a616d2a794a49019