### PR TITLE
Fix flake8 issues and shorten log strings

### DIFF
--- a/contradiction_clipper.py
+++ b/contradiction_clipper.py
@@ -254,7 +254,8 @@ def extract_clip(video_path, start_time, end_time, output_path):
         from moviepy.editor import VideoFileClip
     except Exception as exc:  # pylint: disable=broad-exception-caught
         raise ImportError(
-            "moviepy is required for extracting clips. Install it with 'pip install moviepy'."
+            "moviepy is required for extracting clips. "
+            "Install it with 'pip install moviepy'."
         ) from exc
     logging.info(
         "[i] Extracting clip: %s (%s-%ss)", video_path, start_time, end_time
@@ -288,7 +289,8 @@ def compile_contradiction_montage(
         from moviepy.editor import VideoFileClip, concatenate_videoclips
     except Exception as exc:  # pylint: disable=broad-exception-caught
         raise ImportError(
-            "moviepy is required for compiling montages. Install it with 'pip install moviepy'."
+            "moviepy is required for compiling montages. "
+            "Install it with 'pip install moviepy'."
         ) from exc
     logging.info('[i] Compiling contradiction montage video.')
     cursor = db_conn.cursor()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -11,8 +11,6 @@ from pathlib import Path
 # Ensure repository root is on the module path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-
-
 import contradiction_clipper as cc  # noqa: E402
 # pylint: disable=wrong-import-position
 


### PR DESCRIPTION
## Summary
- split long ImportError strings onto multiple lines
- clean up whitespace in `tests/test_pipeline.py`
- confirm `flake8` passes

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f469b12b08331bfbcd9c58d0782ce