### PR TITLE
Add transcription stage with CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2025-06-29
+### Added
+- `--transcribe` flag to invoke Whisper transcription.
+- New `transcribe_videos` stage populates transcripts table from JSON output.
+- Documentation updated with new flag and dependency notes.
+
 ## [0.1.1] - 2025-06-28
 ### Changed
 - MoviePy is now imported lazily inside `extract_clip` and `compile_contradiction_montage`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Contradiction Clipper automates the extraction of contradictory statements from 
 ### 📦 Dependencies:
 - Python 3.x
 - `yt-dlp`
-- `whisper.cpp`
+- `whisper.cpp` (required for `--transcribe`)
 - `sentence-transformers`
 - `transformers`
 - `moviepy` (version `~=1.0` with FFmpeg installed, required only for `--compile`)
@@ -58,7 +58,7 @@ Ensure `ffmpeg` is installed and available in your system PATH.
 
 2. Run the entire pipeline (download, transcribe, embed, detect contradictions, and compile montage):
 
-                ./contradiction_clipper.py --video_list urls.txt --embed --detect --compile --top_n 20
+                ./contradiction_clipper.py --video_list urls.txt --transcribe --embed --detect --compile --top_n 20
 
 The resulting video montage will be located in:
 
@@ -82,6 +82,7 @@ The resulting video montage will be located in:
 ## 🛠️ Command-Line Arguments
 
 - `--video_list`: Path to URLs list.
+- `--transcribe`: Transcribe downloaded videos with Whisper.
 - `--embed`: Generate semantic embeddings.
 - `--detect`: Detect contradictions.
 - `--compile`: Compile detected contradictions into a montage.


### PR DESCRIPTION
## Summary
- implement `transcribe_videos` using whisper and JSON output
- add `--transcribe` CLI flag to trigger transcription
- mock whisper execution in tests and verify transcripts inserted once
- document new flag and dependency
- note changes in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f49b33ed48331a36a18943050d687