### PR TITLE
Add Flask dashboard option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.5] - 2025-07-02
+### Added
+- Flask dashboard for browsing videos, transcripts, and contradictions.
+- `--dashboard` CLI option to launch the web interface.
+
 ## [0.1.4] - 2025-07-01
 ### Added
 - Parallel download and transcription via `--max_workers` flag.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Contradiction Clipper automates the extraction of contradictory statements from 
 - `transformers`
 - `moviepy` (version `~=1.0` with FFmpeg installed, required only for `--compile`)
 - `roberta-large-mnli` (Hugging Face model for contradiction detection)
+- `Flask` (for the optional dashboard)
 
 ### ⚙️ Installation:
 
@@ -36,7 +37,7 @@ Contradiction Clipper automates the extraction of contradictory statements from 
 
 **Step 2: Install Python dependencies**
 
-        pip install yt-dlp sentence-transformers transformers moviepy~=1.0 torch torchvision torchaudio roberta-large-mnli
+        pip install yt-dlp sentence-transformers transformers moviepy~=1.0 torch torchvision torchaudio roberta-large-mnli Flask
         # moviepy only needed when compiling montages
 
 **Step 3: Setup Whisper (optimized for CPU)**
@@ -63,7 +64,11 @@ Ensure `ffmpeg` is installed and available in your system PATH.
 
 The resulting video montage will be located in:
 
-	output/contradiction_montage.mp4
+        output/contradiction_montage.mp4
+
+3. Launch the dashboard to browse videos, transcripts, and contradictions:
+
+                ./contradiction_clipper.py --dashboard
 
 ---
 
@@ -87,6 +92,7 @@ The resulting video montage will be located in:
 - `--embed`: Generate semantic embeddings.
 - `--detect`: Detect contradictions.
 - `--compile`: Compile detected contradictions into a montage.
+- `--dashboard`: Launch a simple Flask dashboard to browse results.
 - `--top_n`: Number of contradictions to compile (default: 20).
 - `--nli-model`: Hugging Face model path or name for contradiction scoring.
 - `--max_workers`: Number of parallel workers for downloading and transcription (default: 4).

--- a/contradiction_clipper.py
+++ b/contradiction_clipper.py
@@ -12,6 +12,7 @@ import json
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+import dashboard
 
 logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
 
@@ -492,6 +493,11 @@ def main():
         default=4,
         help='Maximum parallel workers for download and transcription.'
     )
+    parser.add_argument(
+        '--dashboard',
+        action='store_true',
+        help='Launch the web dashboard interface.'
+    )
 
     args = parser.parse_args()
 
@@ -520,6 +526,9 @@ def main():
 
     db_conn.close()
     logging.info("[i] Contradiction Clipper pipeline completed successfully.")
+
+    if args.dashboard:
+        dashboard.run_dashboard(DB_PATH)
 
 
 if __name__ == "__main__":

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,98 @@
+import os
+import sqlite3
+import logging
+from flask import Flask, render_template_string, send_from_directory
+
+DB_PATH = 'db/contradictions.db'
+
+
+def create_app(db_path=DB_PATH):
+    """Return a Flask app connected to the specified SQLite database."""
+    app = Flask(__name__)
+
+    def query(sql, args=()):
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.execute(sql, args)
+            return cur.fetchall()
+
+    @app.route('/')
+    def index():
+        return render_template_string(
+            """
+            <h1>Contradiction Clipper Dashboard</h1>
+            <ul>
+              <li><a href='/videos'>Videos</a></li>
+              <li><a href='/transcripts'>Transcripts</a></li>
+              <li><a href='/contradictions'>Contradictions</a></li>
+            </ul>
+            """
+        )
+
+    @app.route('/video/<vid>')
+    def video_file(vid):
+        for ext in ['mp4', 'mkv', 'webm', 'flv', 'mov']:
+            path = os.path.join('videos/raw', f'{vid}.{ext}')
+            if os.path.exists(path):
+                return send_from_directory('videos/raw', f'{vid}.{ext}')
+        return 'Not found', 404
+
+    @app.route('/videos')
+    def list_videos():
+        rows = query('SELECT video_id, url FROM videos')
+        html = ['<h1>Videos</h1>']
+        for row in rows:
+            html.append(
+                f"<div><p>{row['url']}</p>"
+                f"<video width='320' controls src='/video/{row['video_id']}'></video>"  # pylint: disable=line-too-long
+                '</div>'
+            )
+        return '\n'.join(html)
+
+    @app.route('/transcripts')
+    def list_transcripts():
+        rows = query(
+            'SELECT video_id, segment_start, segment_end, text FROM transcripts'
+        )
+        html = ['<h1>Transcripts</h1>']
+        for row in rows:
+            html.append(
+                f"<div><p>{row['text']}</p>"
+                f"<video width='320' controls src='/video/{row['video_id']}#t={row['segment_start']},{row['segment_end']}'></video>"  # pylint: disable=line-too-long
+                '</div>'
+            )
+        return '\n'.join(html)
+
+    @app.route('/contradictions')
+    def list_contradictions():
+        rows = query(
+            '''
+            SELECT c.confidence,
+                   t1.video_id AS vid1, t1.segment_start AS s1, t1.segment_end AS e1, t1.text AS text1,
+                   t2.video_id AS vid2, t2.segment_start AS s2, t2.segment_end AS e2, t2.text AS text2
+            FROM contradictions c
+            JOIN transcripts t1 ON c.segment_a_id = t1.id
+            JOIN transcripts t2 ON c.segment_b_id = t2.id
+            ORDER BY c.confidence DESC
+            '''
+        )
+        html = ['<h1>Contradictions</h1>']
+        for row in rows:
+            html.extend([
+                '<div style="margin-bottom:20px;">',
+                f"<p>Confidence: {row['confidence']:.2f}</p>",
+                f"<p>{row['text1']}</p>",
+                f"<video width='320' controls src='/video/{row['vid1']}#t={row['s1']},{row['e1']}'></video>",
+                f"<p>{row['text2']}</p>",
+                f"<video width='320' controls src='/video/{row['vid2']}#t={row['s2']},{row['e2']}'></video>",
+                '</div>'
+            ])
+        return '\n'.join(html)
+
+    return app
+
+
+def run_dashboard(db_path=DB_PATH, host='127.0.0.1', port=5000):
+    """Launch the Flask dashboard."""
+    logging.info('[i] Starting dashboard on %s:%s', host, port)
+    create_app(db_path).run(host=host, port=port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ torch
 torchvision
 torchaudio
 roberta-large-mnli
+Flask
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,24 @@
+"""Tests for the dashboard Flask app."""
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import dashboard  # noqa: E402
+
+
+def test_dashboard_routes(tmp_path):
+    db = tmp_path / "test.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE videos(video_id TEXT, url TEXT, file_path TEXT, sha256 TEXT, dl_timestamp TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+    app = dashboard.create_app(str(db))
+    client = app.test_client()
+    assert client.get("/").status_code == 200
+    assert client.get("/videos").status_code == 200
+


### PR DESCRIPTION
## Summary
- add new `dashboard.py` module with Flask app for browsing videos, transcripts and contradictions
- integrate dashboard via `--dashboard` CLI option
- document dashboard usage in README and require Flask
- update changelog
- include dashboard unit tests

## Testing
- `pip install Flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f5c2061908331b707531e05a8df1b