### PR TITLE
Add contradiction summary feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.6] - 2025-07-03
+### Added
+- Text summary generation via `summarize_contradictions`.
+- `--summary` CLI flag to write contradiction summaries to a file.
+
 ## [0.1.5] - 2025-07-02
 ### Added
 - Flask dashboard for browsing videos, transcripts, and contradictions.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The resulting video montage will be located in:
 - `--detect`: Detect contradictions.
 - `--compile`: Compile detected contradictions into a montage.
 - `--dashboard`: Launch a simple Flask dashboard to browse results.
+- `--summary`: Output text summaries of contradictions to a file
+  (default: `output/contradictions.txt`).
 - `--top_n`: Number of contradictions to compile (default: 20).
 - `--nli-model`: Hugging Face model path or name for contradiction scoring.
 - `--max_workers`: Number of parallel workers for downloading and transcription (default: 4).


### PR DESCRIPTION
## Summary
- implement `summarize_contradictions` to create human-readable summaries
- support `--summary` CLI option
- write summary when flag provided
- test summary generation for uniqueness
- document new flag in README
- note feature in CHANGELOG

## Testing
- `pip install flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f5e51a78c8331a0514868c370fd88