### PR TITLE
Fix directory creation for summary file

### DIFF
--- a/contradiction_clipper.py
+++ b/contradiction_clipper.py
@@ -464,7 +464,9 @@ def summarize_contradictions(db_conn, output_file="output/contradictions.txt"):
     if not rows:
         logging.warning('[!] No contradictions found to summarize.')
         return
-    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+    dir_name = os.path.dirname(output_file)
+    if dir_name:
+        os.makedirs(dir_name, exist_ok=True)
     with open(output_file, 'w', encoding='utf-8') as fh:
         for (
             vid1,


### PR DESCRIPTION
## Summary
- avoid calling `os.makedirs` when the summary file has no directory component

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f6420e9e88331bd3a0edefe95d277