### PR TITLE
Refactor videos schema to share files

### DIFF
--- a/AGENT_DEV_GUIDE.md
+++ b/AGENT_DEV_GUIDE.md
@@ -20,8 +20,8 @@ A concise handbook for any engineer who continues work on **ContradictionClipper
 ──────────────────────────────────────────────────────────────────────────────
 2. ABSOLUTE “NO DUPLICATE” RULES
 ──────────────────────────────────────────────────────────────────────────────
-A. Never download the same *resolved* URL twice  
-   • Maintain `videos(url PRIMARY KEY, video_id, dl_timestamp, file_path)`  
+A. Never download the same *resolved* URL twice
+   • Maintain `videos(url PRIMARY KEY, file_hash, dl_timestamp)`
    • A UNIQUE constraint on `url` (or canonicalized URL) aborts duplicates.
 
 B. Never transcribe the same *file content* twice  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Database schema versioning via `schema_version` table and migration helpers.
 
+## [0.1.8] - 2025-07-05
+### Changed
+- Schema bumped to v2 introducing a `files` table keyed by SHA256 hashes.
+- `videos` now reference `files` instead of storing paths and hashes directly.
+
 ## [0.1.6] - 2025-07-03
 ### Added
 - Text summary generation via `summarize_contradictions`.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,11 @@ The resulting video montage will be located in:
 
 Contradiction Clipper stores its data in an SQLite database. A `schema_version`
 table tracks migrations so newer releases can upgrade the schema safely. The
-current schema version is `1`.
+current schema version is `2`.
+
+Version 2 introduces a dedicated `files` table keyed by SHA256 hashes. Each
+row represents a unique downloaded file and is referenced by entries in the
+`videos` table.
 
 ---
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -39,7 +39,10 @@ def create_app(db_path=DB_PATH):
 
     @app.route('/videos')
     def list_videos():
-        rows = query('SELECT video_id, url FROM videos')
+        rows = query(
+            'SELECT f.video_id AS video_id, v.url AS url '
+            'FROM videos v JOIN files f ON v.file_hash = f.sha256'
+        )
         html = ['<h1>Videos</h1>']
         for row in rows:
             html.append(

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -12,7 +12,10 @@ def test_dashboard_routes(tmp_path):
     db = tmp_path / "test.db"
     conn = sqlite3.connect(db)
     conn.execute(
-        "CREATE TABLE videos(video_id TEXT, url TEXT, file_path TEXT, sha256 TEXT, dl_timestamp TEXT)"
+        "CREATE TABLE files(sha256 TEXT PRIMARY KEY, video_id TEXT, file_path TEXT, size_bytes INTEGER, hash_ts TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE videos(id INTEGER PRIMARY KEY AUTOINCREMENT, url TEXT UNIQUE, file_hash TEXT, dl_timestamp TEXT)"
     )
     conn.commit()
     conn.close()

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -39,18 +39,19 @@ def test_unique_url_constraint(tmp_path):
     cc.init_db(conn)
     cursor = conn.cursor()
     cursor.execute(
-        "INSERT INTO videos (url, video_id, file_path, sha256, dl_timestamp) "
+        "INSERT INTO files (sha256, video_id, file_path, size_bytes, hash_ts) "
         "VALUES (?, ?, ?, ?, ?)",
-        ("http://example.com/a", "a", "/tmp/a.mp4", "hash1", "now"),
+        ("hash1", "a", "/tmp/a.mp4", 1, "now"),
+    )
+    cursor.execute(
+        "INSERT INTO videos (url, file_hash, dl_timestamp) VALUES (?, ?, ?)",
+        ("http://example.com/a", "hash1", "now"),
     )
     conn.commit()
     with pytest.raises(sqlite3.IntegrityError):
         cursor.execute(
-            (
-                "INSERT INTO videos (url, video_id, file_path, sha256, "
-                "dl_timestamp) VALUES (?, ?, ?, ?, ?)"
-            ),
-            ("http://example.com/a", "b", "/tmp/b.mp4", "hash2", "now"),
+            "INSERT INTO videos (url, file_hash, dl_timestamp) VALUES (?, ?, ?)",
+            ("http://example.com/a", "hash2", "now"),
         )
         conn.commit()
     conn.close()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -120,9 +120,14 @@ def test_transcribe_videos_once(tmp_path, monkeypatch):
     video_path = tmp_path / "v1.mp4"
     video_path.write_bytes(b"data")
     cursor.execute(
-        "INSERT INTO videos(url, video_id, file_path, sha256, dl_timestamp)"
+        "INSERT INTO files(sha256, video_id, file_path, size_bytes, hash_ts)"
         " VALUES(?,?,?,?,?)",
-        ("http://x/v1", "v1", str(video_path), "hash", "now"),
+        ("hash", "v1", str(video_path), 4, "now"),
+    )
+    cursor.execute(
+        "INSERT INTO videos(url, file_hash, dl_timestamp)"
+        " VALUES(?,?,?)",
+        ("http://x/v1", "hash", "now"),
     )
     conn.commit()
 
@@ -151,9 +156,14 @@ def test_transcribe_parallel_once(tmp_path, monkeypatch):
     video_path = tmp_path / "v2.mp4"
     video_path.write_bytes(b"data")
     cursor.execute(
-        "INSERT INTO videos(url, video_id, file_path, sha256, dl_timestamp)"
+        "INSERT INTO files(sha256, video_id, file_path, size_bytes, hash_ts)"
         " VALUES(?,?,?,?,?)",
-        ("http://x/v2", "v2", str(video_path), "hash2", "now"),
+        ("hash2", "v2", str(video_path), 4, "now"),
+    )
+    cursor.execute(
+        "INSERT INTO videos(url, file_hash, dl_timestamp)"
+        " VALUES(?,?,?)",
+        ("http://x/v2", "hash2", "now"),
     )
     conn.commit()
 


### PR DESCRIPTION
## Summary
- add `files` table and reference it from `videos`
- update `process_videos` to reuse existing files when hashes match
- transcribe from the `files` table
- adjust dashboard queries for the new schema
- bump schema version and document the change
- update tests for the new tables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f6b1bc9a083318aaa6f9bc52bfb2a