### PR TITLE
Fix flake8 warnings and reformat codebase

### DIFF
--- a/AGENT_DEV_GUIDE.md
+++ b/AGENT_DEV_GUIDE.md
@@ -24,23 +24,23 @@ A. Never download the same *resolved* URL twice
    • Maintain `videos(url PRIMARY KEY, file_hash, dl_timestamp)`
    • A UNIQUE constraint on `url` (or canonicalized URL) aborts duplicates.
 
-B. Never transcribe the same *file content* twice  
-   • After download and before STT, compute `sha256` of the **binary file**.  
-   • Table `files(hash PRIMARY KEY, video_id, path, size_bytes, hash_ts)`  
+B. Never transcribe the same *file content* twice
+   • After download and before STT, compute `sha256` of the **binary file**.
+   • Table `files(hash PRIMARY KEY, video_id, path, size_bytes, hash_ts)`
    • If the hash exists, skip STT; ensure any new URL pointing to identical
      content links to that hash—no second entry, no second transcription.
 
-C. Never embed or detect contradictions twice for the same transcript row  
-   • Use `UNIQUE(transcript_id)` in `embeddings` and  
+C. Never embed or detect contradictions twice for the same transcript row
+   • Use `UNIQUE(transcript_id)` in `embeddings` and
      `UNIQUE(segment_a_id, segment_b_id)` in `contradictions`.
 
 ──────────────────────────────────────────────────────────────────────────────
 3. PIPELINE CHECKPOINTS (⊕ = must be idempotent)
 ──────────────────────────────────────────────────────────────────────────────
-⊕ download → compute hash  
-⊕ transcribe (only if hash unseen) → write JSON + `transcripts` rows  
-⊕ embed (only rows whose embeddings don’t exist)  
-⊕ detect contradictions (only new pairs)  
+⊕ download → compute hash
+⊕ transcribe (only if hash unseen) → write JSON + `transcripts` rows
+⊕ embed (only rows whose embeddings don’t exist)
+⊕ detect contradictions (only new pairs)
 ⊕ compile montage (deterministic ordering by `confidence DESC, hash ASC`)
 
 Use transactions per major step; commit only when the sub-step finishes.
@@ -48,13 +48,13 @@ Use transactions per major step; commit only when the sub-step finishes.
 ──────────────────────────────────────────────────────────────────────────────
 4. CODING CONTRACT
 ──────────────────────────────────────────────────────────────────────────────
-• argparse  All new flags documented via `--help` and follow UNIX patterns.  
+• argparse  All new flags documented via `--help` and follow UNIX patterns.
 • logging   Use logging with `[i]`, `[!]`, `[x]`, `[DEBUG]` prefixes (already
-  established).  
+  established).
 • Error Handling  NEVER swallow exceptions; catch, log, and continue or abort
-  cleanly.  
+  cleanly.
 • Tests     Add basic unit tests (pytest) for hash detection, DB uniqueness,
-  and duplicate skipping logic.  
+  and duplicate skipping logic.
 • Documentation  Update README & this guide whenever the CLI or DB schema
   changes—single source of truth.
 
@@ -62,18 +62,18 @@ Use transactions per major step; commit only when the sub-step finishes.
 5. FUTURE NICE-TO-HAVES (NOT YET MANDATORY)
 ──────────────────────────────────────────────────────────────────────────────
 • Concurrent download + STT implemented via `--max_workers` flag.
-• `--force` flags to override duplicate protections intentionally.  
-• GUI wrapper (Flask/Electron) reading the same DB.  
-• Pluggable STT and NLI back-ends (GPU Whisper, distilled NLI, etc.).  
+• `--force` flags to override duplicate protections intentionally.
+• GUI wrapper (Flask/Electron) reading the same DB.
+• Pluggable STT and NLI back-ends (GPU Whisper, distilled NLI, etc.).
 • Integration tests in CI (GitHub Actions) using small public domain videos.
 
 ──────────────────────────────────────────────────────────────────────────────
 6. HAND-OFF CHECKLIST
 ──────────────────────────────────────────────────────────────────────────────
 ☑  All schema migrations version-controlled via the `schema_version` table.
-☐  Code passes pylint / flake8 with < 5 warnings.  
-☐  `README.md` reflects every new CLI flag and environment prerequisite.  
-☐  `CHANGELOG.md` updated with date, author, and high-level bullet points.  
+☐  Code passes pylint / flake8 with < 5 warnings.
+☐  `README.md` reflects every new CLI flag and environment prerequisite.
+☐  `CHANGELOG.md` updated with date, author, and high-level bullet points.
 ☐  Manual test: run pipeline twice on same URL list → second run does **zero**
    work beyond log lines (“already exists — skipping”).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Contradiction Clipper automates the extraction of contradictory statements from 
 ### ⚙️ Installation:
 
 **Step 1: Clone the repository**
-	
+
 	git clone <your_repo_url>
         cd ContradictionClipper
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -3,7 +3,7 @@ import sqlite3
 import logging
 from flask import Flask, render_template_string, send_from_directory
 
-DB_PATH = 'db/contradictions.db'
+DB_PATH = "db/contradictions.db"
 
 
 def create_app(db_path=DB_PATH):
@@ -16,7 +16,7 @@ def create_app(db_path=DB_PATH):
             cur = conn.execute(sql, args)
             return cur.fetchall()
 
-    @app.route('/')
+    @app.route("/")
     def index():
         return render_template_string(
             """
@@ -29,73 +29,90 @@ def create_app(db_path=DB_PATH):
             """
         )
 
-    @app.route('/video/<vid>')
+    @app.route("/video/<vid>")
     def video_file(vid):
-        for ext in ['mp4', 'mkv', 'webm', 'flv', 'mov']:
-            path = os.path.join('videos/raw', f'{vid}.{ext}')
+        for ext in ["mp4", "mkv", "webm", "flv", "mov"]:
+            path = os.path.join("videos/raw", f"{vid}.{ext}")
             if os.path.exists(path):
-                return send_from_directory('videos/raw', f'{vid}.{ext}')
-        return 'Not found', 404
+                return send_from_directory("videos/raw", f"{vid}.{ext}")
+        return "Not found", 404
 
-    @app.route('/videos')
+    @app.route("/videos")
     def list_videos():
         rows = query(
-            'SELECT f.video_id AS video_id, v.url AS url '
-            'FROM videos v JOIN files f ON v.file_hash = f.sha256'
+            "SELECT f.video_id AS video_id, v.url AS url "
+            "FROM videos v JOIN files f ON v.file_hash = f.sha256"
         )
-        html = ['<h1>Videos</h1>']
+        html = ["<h1>Videos</h1>"]
         for row in rows:
             html.append(
                 f"<div><p>{row['url']}</p>"
-                f"<video width='320' controls src='/video/{row['video_id']}'></video>"  # pylint: disable=line-too-long
-                '</div>'
+                f"<video width='320' controls src='/video/{row['video_id']}'>"
+                "</video>"
+                "</div>"
             )
-        return '\n'.join(html)
+        return "\n".join(html)
 
-    @app.route('/transcripts')
+    @app.route("/transcripts")
     def list_transcripts():
         rows = query(
-            'SELECT video_id, segment_start, segment_end, text FROM transcripts'
+            "SELECT video_id, segment_start, segment_end, text "
+            "FROM transcripts"
         )
-        html = ['<h1>Transcripts</h1>']
+        html = ["<h1>Transcripts</h1>"]
         for row in rows:
             html.append(
                 f"<div><p>{row['text']}</p>"
-                f"<video width='320' controls src='/video/{row['video_id']}#t={row['segment_start']},{row['segment_end']}'></video>"  # pylint: disable=line-too-long
-                '</div>'
+                f"<video width='320' controls src='/video/{row['video_id']}#t="
+                f"{row['segment_start']},{row['segment_end']}'></video>"
+                "</div>"
             )
-        return '\n'.join(html)
+        return "\n".join(html)
 
-    @app.route('/contradictions')
+    @app.route("/contradictions")
     def list_contradictions():
         rows = query(
-            '''
+            """
             SELECT c.confidence,
-                   t1.video_id AS vid1, t1.segment_start AS s1, t1.segment_end AS e1, t1.text AS text1,
-                   t2.video_id AS vid2, t2.segment_start AS s2, t2.segment_end AS e2, t2.text AS text2
+                   t1.video_id AS vid1,
+                   t1.segment_start AS s1,
+                   t1.segment_end AS e1,
+                   t1.text AS text1,
+                   t2.video_id AS vid2,
+                   t2.segment_start AS s2,
+                   t2.segment_end AS e2,
+                   t2.text AS text2
             FROM contradictions c
             JOIN transcripts t1 ON c.segment_a_id = t1.id
             JOIN transcripts t2 ON c.segment_b_id = t2.id
             ORDER BY c.confidence DESC
-            '''
+            """
         )
-        html = ['<h1>Contradictions</h1>']
+        html = ["<h1>Contradictions</h1>"]
         for row in rows:
-            html.extend([
-                '<div style="margin-bottom:20px;">',
-                f"<p>Confidence: {row['confidence']:.2f}</p>",
-                f"<p>{row['text1']}</p>",
-                f"<video width='320' controls src='/video/{row['vid1']}#t={row['s1']},{row['e1']}'></video>",
-                f"<p>{row['text2']}</p>",
-                f"<video width='320' controls src='/video/{row['vid2']}#t={row['s2']},{row['e2']}'></video>",
-                '</div>'
-            ])
-        return '\n'.join(html)
+            html.extend(
+                [
+                    '<div style="margin-bottom:20px;">',
+                    f"<p>Confidence: {row['confidence']:.2f}</p>",
+                    f"<p>{row['text1']}</p>",
+                    (
+                        "<video width='320' controls src='/video/"
+                        f"{row['vid1']}'#t={row['s1']},{row['e1']}'></video>"
+                    ),
+                    f"<p>{row['text2']}</p>",
+                    (
+                        "<video width='320' controls src='/video/"
+                        f"{row['vid2']}'#t={row['s2']},{row['e2']}'></video>"
+                    ),
+                    "</div>",
+                ]
+            )
+        return "\n".join(html)
 
     return app
 
 
-def run_dashboard(db_path=DB_PATH, host='127.0.0.1', port=5000):
+def run_dashboard(db_path=DB_PATH, host="127.0.0.1", port=5000):
     """Launch the Flask dashboard."""
-    logging.info('[i] Starting dashboard on %s:%s', host, port)
+    logging.info("[i] Starting dashboard on %s:%s", host, port)
     create_app(db_path).run(host=host, port=port)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -12,10 +12,13 @@ def test_dashboard_routes(tmp_path):
     db = tmp_path / "test.db"
     conn = sqlite3.connect(db)
     conn.execute(
-        "CREATE TABLE files(sha256 TEXT PRIMARY KEY, video_id TEXT, file_path TEXT, size_bytes INTEGER, hash_ts TEXT)"
+        "CREATE TABLE files(sha256 TEXT PRIMARY KEY,"
+        " video_id TEXT, file_path TEXT, size_bytes INTEGER, hash_ts TEXT)"
     )
     conn.execute(
-        "CREATE TABLE videos(id INTEGER PRIMARY KEY AUTOINCREMENT, url TEXT UNIQUE, file_hash TEXT, dl_timestamp TEXT)"
+        "CREATE TABLE videos("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, url TEXT UNIQUE,"
+        " file_hash TEXT, dl_timestamp TEXT)"
     )
     conn.commit()
     conn.close()
@@ -24,4 +27,3 @@ def test_dashboard_routes(tmp_path):
     client = app.test_client()
     assert client.get("/").status_code == 200
     assert client.get("/videos").status_code == 200
-

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -18,6 +18,7 @@ sys.modules.setdefault("moviepy", types.ModuleType("moviepy"))
 sys.modules.setdefault("moviepy.editor", types.ModuleType("moviepy.editor"))
 
 import contradiction_clipper as cc  # noqa: E402
+
 # pylint: disable=wrong-import-position
 
 
@@ -50,7 +51,8 @@ def test_unique_url_constraint(tmp_path):
     conn.commit()
     with pytest.raises(sqlite3.IntegrityError):
         cursor.execute(
-            "INSERT INTO videos (url, file_hash, dl_timestamp) VALUES (?, ?, ?)",
+            "INSERT INTO videos (url, file_hash, dl_timestamp) "
+            "VALUES (?, ?, ?)",
             ("http://example.com/a", "hash2", "now"),
         )
         conn.commit()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -13,6 +13,7 @@ import subprocess
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import contradiction_clipper as cc  # noqa: E402
+
 # pylint: disable=wrong-import-position
 
 
@@ -125,8 +126,7 @@ def test_transcribe_videos_once(tmp_path, monkeypatch):
         ("hash", "v1", str(video_path), 4, "now"),
     )
     cursor.execute(
-        "INSERT INTO videos(url, file_hash, dl_timestamp)"
-        " VALUES(?,?,?)",
+        "INSERT INTO videos(url, file_hash, dl_timestamp)" " VALUES(?,?,?)",
         ("http://x/v1", "hash", "now"),
     )
     conn.commit()
@@ -135,11 +135,15 @@ def test_transcribe_videos_once(tmp_path, monkeypatch):
         out_dir = tmp_path / "transcripts"
         out_dir.mkdir(exist_ok=True)
         out_file = out_dir / "v1.json"
-        out_file.write_text('{"segments": [{"start": 0, "end": 1, "text": "hi"}]}')
+        out_file.write_text(
+            '{"segments": [{"start": 0, "end": 1, "text": "hi"}]}'
+        )
         return subprocess.CompletedProcess(cmd, 0, "", "")
 
     monkeypatch.chdir(tmp_path)
-    with mock.patch("contradiction_clipper.subprocess.run", side_effect=fake_run) as mock_run:
+    with mock.patch(
+        "contradiction_clipper.subprocess.run", side_effect=fake_run
+    ) as mock_run:
         cc.transcribe_videos(conn)
         cc.transcribe_videos(conn)
         assert mock_run.call_count == 1
@@ -161,8 +165,7 @@ def test_transcribe_parallel_once(tmp_path, monkeypatch):
         ("hash2", "v2", str(video_path), 4, "now"),
     )
     cursor.execute(
-        "INSERT INTO videos(url, file_hash, dl_timestamp)"
-        " VALUES(?,?,?)",
+        "INSERT INTO videos(url, file_hash, dl_timestamp)" " VALUES(?,?,?)",
         ("http://x/v2", "hash2", "now"),
     )
     conn.commit()
@@ -171,11 +174,15 @@ def test_transcribe_parallel_once(tmp_path, monkeypatch):
         out_dir = tmp_path / "transcripts"
         out_dir.mkdir(exist_ok=True)
         out_file = out_dir / "v2.json"
-        out_file.write_text('{"segments": [{"start": 0, "end": 1, "text": "hi"}]}')
+        out_file.write_text(
+            '{"segments": [{"start": 0, "end": 1, "text": "hi"}]}'
+        )
         return subprocess.CompletedProcess(cmd, 0, "", "")
 
     monkeypatch.chdir(tmp_path)
-    with mock.patch("contradiction_clipper.subprocess.run", side_effect=fake_run) as mock_run:
+    with mock.patch(
+        "contradiction_clipper.subprocess.run", side_effect=fake_run
+    ) as mock_run:
         cc.transcribe_videos(conn, max_workers=2)
         cc.transcribe_videos(conn, max_workers=2)
         assert mock_run.call_count == 1
@@ -226,7 +233,9 @@ def test_process_videos_duplicate_files(tmp_path):
         path.write_bytes(b"data")
         return str(path), vid
 
-    with mock.patch("contradiction_clipper.download_video", side_effect=fake_dl):
+    with mock.patch(
+        "contradiction_clipper.download_video", side_effect=fake_dl
+    ):
         cc.process_videos(str(list_file), db_path, max_workers=1)
 
     cursor = conn.cursor()


### PR DESCRIPTION
## Summary
- reformat Python sources to comply with 79-char line limit
- clean up trailing whitespace across docs and code
- split long strings in dashboard and tests
- tweak docstrings and logging statements

## Testing
- `flake8 | wc -l`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f7af3e3908331a0fa8f5b0e6dd4af