### PR TITLE
Improve transcript embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.13] - 06-27-2025
+### Changed
+- Replaced placeholder SHA-256 transcript embeddings with actual vectors from
+  `sentence-transformers` stored as binary blobs.
+
 ## [0.1.11] - 06-27-2025
 ### Added
 - `--whisper-bin` CLI option to specify the path to the Whisper binary.


### PR DESCRIPTION
## Summary
- generate real embeddings using sentence-transformers
- cache embedding models
- adjust pipeline tests to mock the new embedding loader
- document embedding change in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f83bdcc908331816b926574156a06