### PR TITLE
Add Docker build files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use lightweight Python image
+FROM python:3.10-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ffmpeg git build-essential cmake && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy project files
+COPY . .
+
+# Build whisper.cpp and place binary in project root
+RUN chmod +x build_whisper.sh && ./build_whisper.sh
+
+CMD ["python", "contradiction_clipper.py"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,26 @@ Contradiction Clipper automates the extraction of contradictory statements from 
 
 ## 🚀 Quick Start
 
-### 📦 Dependencies:
+### 🐳 Docker (Preferred)
+
+Build the Docker image:
+
+```
+docker build -t contradiction-clipper .
+```
+
+Run the pipeline (mount the working directory so results persist):
+
+```
+docker run --rm -v "$PWD":/app contradiction-clipper \
+    --video_list urls.txt --transcribe --embed --detect --compile
+```
+
+---
+
+### 📦 Manual Installation
+
+#### Dependencies
 - Python 3.x
 - `yt-dlp`
 - `whisper.cpp` (required for `--transcribe`)
@@ -29,11 +48,11 @@ Contradiction Clipper automates the extraction of contradictory statements from 
 - The NLI model (`roberta-large-mnli`) is automatically downloaded by `transformers`
 - NLI models are cached in memory during detection for faster repeated runs
 
-### ⚙️ Installation:
+#### Installation
 
 **Step 1: Clone the repository**
 
-	git clone <your_repo_url>
+        git clone <your_repo_url>
         cd ContradictionClipper
 
 **Step 2: Install Python dependencies**
@@ -44,14 +63,15 @@ Contradiction Clipper automates the extraction of contradictory statements from 
 
 **Step 3: Setup Whisper (optimized for CPU)**
 
-	git clone https://github.com/ggerganov/whisper.cpp.git
-	cd whisper.cpp
+        git clone https://github.com/ggerganov/whisper.cpp.git
+        cd whisper.cpp
         make
         cp ./whisper ../
 
         # If whisper is located elsewhere, pass its path via --whisper-bin
 
 Ensure `ffmpeg` is installed and available in your system PATH.
+
 
 ---
 

--- a/build_whisper.sh
+++ b/build_whisper.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Robustly build whisper.cpp and place the binary in the project root.
+set -euo pipefail
+set -x
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$ROOT_DIR"
+
+echo "[i] Cloning whisper.cpp repository"
+git clone --depth 1 https://github.com/ggerganov/whisper.cpp.git
+
+echo "[i] Building whisper.cpp"
+cd whisper.cpp
+make
+
+echo "[i] Copying binary"
+cp ./main "$ROOT_DIR/whisper"
+
+echo "[i] Cleaning up"
+cd "$ROOT_DIR"
+rm -rf whisper.cpp
+
+echo "[i] Whisper build complete"


### PR DESCRIPTION
## Summary
- reorder README so Docker instructions appear first
- make build_whisper.sh more verbose and fail-safe

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ffcecca048331addf2fa2f83c007c