### PR TITLE
Fix missing whisper model download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 - `install_whisper.sh` script automates cloning and building `whisper.cpp`.
 - README updated to reference the new installation script.
 
+## [0.1.15] - 06-28-2025
+### Fixed
+- `install_whisper.sh` and `build_whisper.sh` now download the default
+  Whisper model so transcription works out of the box.
+- `transcribe_videos` checks for the binary and model before running and
+  logs a helpful error if either is missing.
+
 ## [0.1.13] - 06-27-2025
 ### Changed
 - Replaced placeholder SHA-256 transcript embeddings with actual vectors from

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ docker run --rm -v "$PWD":/app contradiction-clipper \
 
         ./install_whisper.sh
 
-        # If the binary is located elsewhere, pass its path via --whisper-bin
+        # This builds whisper.cpp and downloads the default model to ./models
+        # If the binary lives elsewhere, pass its path via --whisper-bin
 
 Docker users may skip Steps 2 and 3 after building the image because it installs
 dependencies and runs `install_whisper.sh` automatically.

--- a/build_whisper.sh
+++ b/build_whisper.sh
@@ -20,4 +20,15 @@ echo "[i] Cleaning up"
 cd "$ROOT_DIR"
 rm -rf whisper.cpp
 
+MODEL_DIR="$ROOT_DIR/models"
+MODEL_FILE="$MODEL_DIR/ggml-base.en.bin"
+if [ ! -f "$MODEL_FILE" ]; then
+    echo "[i] Downloading default Whisper model..."
+    mkdir -p "$MODEL_DIR"
+    curl -L -o "$MODEL_FILE" \
+        https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin
+else
+    echo "[i] Whisper model already present"
+fi
+
 echo "[i] Whisper build complete"

--- a/contradiction_clipper.py
+++ b/contradiction_clipper.py
@@ -278,6 +278,17 @@ def transcribe_videos(db_conn, whisper_bin="./whisper", max_workers=4):
     Populate the transcripts table.
     """
     logging.info("[i] Transcribing videos with %s workers.", max_workers)
+    if not os.path.isfile(whisper_bin):
+        logging.error("[x] Whisper binary not found: %s", whisper_bin)
+        logging.error("[x] Run install_whisper.sh or pass --whisper-bin")
+        return
+    model_file = os.path.join("models", "ggml-base.en.bin")
+    if not os.path.isfile(model_file):
+        logging.error(
+            "[x] Whisper model missing: %s. Run install_whisper.sh to download it.",
+            model_file,
+        )
+        return
     db_conn.execute("PRAGMA journal_mode=WAL")
     cursor = db_conn.cursor()
     cursor.execute("SELECT video_id, file_path FROM files")

--- a/install_whisper.sh
+++ b/install_whisper.sh
@@ -29,6 +29,17 @@ echo "[i] Moving binary to $WHISPER_BIN"
 cp ./build/bin/main "$WHISPER_BIN"
 cd "$ROOT_DIR"
 
+MODEL_DIR="$ROOT_DIR/models"
+MODEL_FILE="$MODEL_DIR/ggml-base.en.bin"
+if [ ! -f "$MODEL_FILE" ]; then
+    echo "[i] Downloading default Whisper model..."
+    mkdir -p "$MODEL_DIR"
+    curl -L -o "$MODEL_FILE" \
+        https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin
+else
+    echo "[i] Whisper model already present"
+fi
+
 if [ -f "$WHISPER_BIN" ] && [ -x "$WHISPER_BIN" ]; then
     echo "[i] Whisper installed successfully."
 else


### PR DESCRIPTION
## Summary
- download default Whisper model in `build_whisper.sh` and `install_whisper.sh`
- check for Whisper binary/model before transcription
- document Whisper model setup in README
- update changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686018c08c108331a13de94a3ca37dca