### PR TITLE
Update whisper install scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
   is missing.
 - README updated with note about automatic installation and Docker usage.
 
+## [0.1.17] - 06-30-2025
+### Changed
+- Installation scripts now copy `whisper-cli` from whisper.cpp instead of `main`.
+- README notes the binary change in the Whisper setup instructions.
+
 ## [0.1.15] - 06-28-2025
 ### Fixed
 - `install_whisper.sh` and `build_whisper.sh` now download the default

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Run the pipeline (mount the working directory so results persist):
         ./install_whisper.sh
 
         # This builds whisper.cpp and downloads the default model to ./models
+        # The script copies the whisper-cli binary to ./whisper for use by
+        # the pipeline.
         # If the binary lives elsewhere, pass its path via --whisper-bin
         # If you skip this step, the pipeline will automatically run the
         # script when transcription is requested.

--- a/build_whisper.sh
+++ b/build_whisper.sh
@@ -14,7 +14,7 @@ cd whisper.cpp
 make
 
 echo "[i] Copying binary"
-cp ./build/bin/main "$ROOT_DIR/whisper"
+cp ./build/bin/whisper-cli "$ROOT_DIR/whisper"
 
 echo "[i] Cleaning up"
 cd "$ROOT_DIR"

--- a/install_whisper.sh
+++ b/install_whisper.sh
@@ -26,7 +26,7 @@ echo "[i] Building whisper.cpp"
 make $MAKE_FLAGS
 
 echo "[i] Moving binary to $WHISPER_BIN"
-cp ./build/bin/main "$WHISPER_BIN"
+cp ./build/bin/whisper-cli "$WHISPER_BIN"
 cd "$ROOT_DIR"
 
 MODEL_DIR="$ROOT_DIR/models"


### PR DESCRIPTION
## Summary
- fix install_whisper.sh and build_whisper.sh to copy whisper-cli
- note new binary name in README
- document change in CHANGELOG

## Testing
- `./whisper --help | head -n 5`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask' and 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6860418373ac8331b7bfc49141b644bf