### PR TITLE
Add model flag to Whisper call

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ dependencies and runs `install_whisper.sh` automatically.
 
 Ensure `ffmpeg` is installed and available in your system PATH.
 
+### Transcription
+
+When running the pipeline with `--transcribe`, the Whisper binary is
+now invoked with `--model models/ggml-base.en.bin` so the English base
+model is always used. If the transcript JSON file is not created,
+Whisper's stdout and stderr are logged to help diagnose the issue.
+
 
 ---
 

--- a/contradiction_clipper.py
+++ b/contradiction_clipper.py
@@ -329,12 +329,11 @@ def transcribe_videos(db_conn, whisper_bin="./whisper", max_workers=4):
             [
                 whisper_bin,
                 path,
-                "--output_format",
-                "json",
-                "--output_dir",
-                "transcripts",
-                "--output_file",
-                vid,
+                "--model",
+                "models/ggml-base.en.bin",
+                "-oj",
+                "--output-file",
+                os.path.join("transcripts", vid),
             ],
             capture_output=True,
             text=True,
@@ -352,6 +351,16 @@ def transcribe_videos(db_conn, whisper_bin="./whisper", max_workers=4):
         if not os.path.exists(out_json):
             logging.error(
                 "[x] [%s] Transcript output missing for %s", thread_name, vid
+            )
+            logging.debug(
+                "[DEBUG] [%s] Whisper stdout: %s",
+                thread_name,
+                result.stdout.strip(),
+            )
+            logging.debug(
+                "[DEBUG] [%s] Whisper stderr: %s",
+                thread_name,
+                result.stderr.strip(),
             )
             conn_w.close()
             return


### PR DESCRIPTION
## Summary
- update Whisper invocation to include `--model models/ggml-base.en.bin`
- log Whisper stdout/err when transcript output is missing
- document transcription behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68606fda05b48331afebdf9c3466465d