### PR TITLE
Add verbose flag and improve logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.16] - 06-29-2025
-### Added
-- Automatic invocation of `install_whisper.sh` when the Whisper binary or model
-  is missing.
-- README updated with note about automatic installation and Docker usage.
+## [0.1.18] - 07-01-2025
+### Changed
+- `transcribe_videos` now logs Whisper stdout and stderr at ERROR level when the
+  transcript output is missing.
+- Added `--verbose` CLI flag to enable debug logging.
+- README updated with the new flag.
 
 ## [0.1.17] - 06-30-2025
 ### Changed
 - Installation scripts now copy `whisper-cli` from whisper.cpp instead of `main`.
 - README notes the binary change in the Whisper setup instructions.
+
+## [0.1.16] - 06-29-2025
+### Added
+- Automatic invocation of `install_whisper.sh` when the Whisper binary or model
+  is missing.
+- README updated with note about automatic installation and Docker usage.
 
 ## [0.1.15] - 06-28-2025
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ row represents a unique downloaded file and is referenced by entries in the
 - `--top_n`: Number of contradictions to compile (default: 20).
 - `--nli-model`: Hugging Face model path or name for contradiction scoring.
 - `--max_workers`: Number of parallel workers for downloading and transcription (default: 4).
+- `--verbose`: Enable debug logging for troubleshooting.
 
 ---
 

--- a/contradiction_clipper.py
+++ b/contradiction_clipper.py
@@ -352,13 +352,13 @@ def transcribe_videos(db_conn, whisper_bin="./whisper", max_workers=4):
             logging.error(
                 "[x] [%s] Transcript output missing for %s", thread_name, vid
             )
-            logging.debug(
-                "[DEBUG] [%s] Whisper stdout: %s",
+            logging.error(
+                "[x] [%s] Whisper stdout: %s",
                 thread_name,
                 result.stdout.strip(),
             )
-            logging.debug(
-                "[DEBUG] [%s] Whisper stderr: %s",
+            logging.error(
+                "[x] [%s] Whisper stderr: %s",
                 thread_name,
                 result.stderr.strip(),
             )
@@ -743,6 +743,11 @@ def main():
         help="Maximum parallel workers for download and transcription.",
     )
     parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose debug logging.",
+    )
+    parser.add_argument(
         "--dashboard",
         action="store_true",
         help="Launch the web dashboard interface.",
@@ -759,6 +764,10 @@ def main():
     )
 
     args = parser.parse_args()
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+        logging.debug("[DEBUG] Verbose logging enabled")
 
     os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
     db_conn = sqlite3.connect(DB_PATH)


### PR DESCRIPTION
## Summary
- print Whisper stdout/stderr at ERROR level when transcripts are missing
- add `--verbose` CLI flag to enable debug logging
- document new flag in README
- note change in `CHANGELOG`

## Testing
- `pip install numpy Flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68607f1f2b348331b2bd41a4ecb1a18c