### PR TITLE
Fix whisper build to support mp4 input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        ffmpeg git build-essential cmake curl ccache && \
+        ffmpeg libavcodec-dev libavformat-dev libavutil-dev \
+        git build-essential cmake curl ccache && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy requirements and install Python dependencies

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Docker users may skip Steps 2 and 3 after building the image because it installs
 dependencies and runs `install_whisper.sh` automatically.
 
 Ensure `ffmpeg` is installed and available in your system PATH.
+If you plan to build Whisper yourself (outside Docker), install the
+`libavcodec-dev`, `libavformat-dev`, and `libavutil-dev` packages so the
+binary can decode common formats like MP4.
 
 ### Transcription
 

--- a/build_whisper.sh
+++ b/build_whisper.sh
@@ -11,7 +11,14 @@ git clone --depth 1 https://github.com/ggerganov/whisper.cpp.git
 
 echo "[i] Building whisper.cpp"
 cd whisper.cpp
-make
+MAKE_FLAGS="WHISPER_FFMPEG=1"
+if command -v nvidia-smi >/dev/null 2>&1; then
+    echo "[i] Nvidia GPU detected; building with CUDA and FFmpeg support."
+    MAKE_FLAGS="WHISPER_CUBLAS=1 WHISPER_FFMPEG=1"
+else
+    echo "[i] Building with FFmpeg support."
+fi
+make $MAKE_FLAGS
 
 echo "[i] Copying binary"
 cp ./build/bin/whisper-cli "$ROOT_DIR/whisper"

--- a/install_whisper.sh
+++ b/install_whisper.sh
@@ -16,10 +16,12 @@ fi
 
 cd "$WHISPER_DIR"
 
-MAKE_FLAGS=""
+MAKE_FLAGS="WHISPER_FFMPEG=1"
 if command -v nvidia-smi >/dev/null 2>&1; then
-    echo "[i] Nvidia GPU detected; building with CUDA support."
-    MAKE_FLAGS="WHISPER_CUBLAS=1"
+    echo "[i] Nvidia GPU detected; building with CUDA and FFmpeg support."
+    MAKE_FLAGS="WHISPER_CUBLAS=1 WHISPER_FFMPEG=1"
+else
+    echo "[i] Building with FFmpeg support."
 fi
 
 echo "[i] Building whisper.cpp"


### PR DESCRIPTION
## Summary
- enable ffmpeg decoding when building `whisper.cpp`
- install ffmpeg dev libraries in Dockerfile
- document ffmpeg build deps in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68609b1f3a0483318a2d025c3b51e81e