### PR TITLE
Add log level flag and whisper diagnostics

### DIFF
--- a/AGENT_DEV_GUIDE.md
+++ b/AGENT_DEV_GUIDE.md
@@ -51,6 +51,7 @@ Use transactions per major step; commit only when the sub-step finishes.
 • argparse  All new flags documented via `--help` and follow UNIX patterns.
 • logging   Use logging with `[i]`, `[!]`, `[x]`, `[DEBUG]` prefixes (already
   established).
+• `--log-level` flag controls global verbosity; default is `INFO`.
 • Error Handling  NEVER swallow exceptions; catch, log, and continue or abort
   cleanly.
 • Tests     Add basic unit tests (pytest) for hash detection, DB uniqueness,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.18] - 07-01-2025
+### Added
+- `--log-level` flag to control logging verbosity.
+- install script output now logged and checked for errors.
+- Unit test covers failing Whisper installation.
+
 ## [0.1.16] - 06-29-2025
 ### Added
 - Automatic invocation of `install_whisper.sh` when the Whisper binary or model

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Whisper's stdout and stderr are logged to help diagnose the issue.
 
                 ./contradiction_clipper.py --video_list urls.txt --transcribe --embed --detect --compile --top_n 20 --max_workers 4
                 # add --whisper-bin /path/to/whisper if the binary lives elsewhere
+                # set --log-level DEBUG for more verbose logs
 
 The resulting video montage will be located in:
 
@@ -154,6 +155,7 @@ row represents a unique downloaded file and is referenced by entries in the
 - `--top_n`: Number of contradictions to compile (default: 20).
 - `--nli-model`: Hugging Face model path or name for contradiction scoring.
 - `--max_workers`: Number of parallel workers for downloading and transcription (default: 4).
+- `--log-level`: Logging verbosity (DEBUG, INFO, WARNING, ERROR).
 
 ---
 


### PR DESCRIPTION
## Summary
- add `--log-level` CLI flag and document it
- log stdout/stderr from the whisper install script
- surface whisper stdout/stderr when transcription fails
- support configurable logging level
- test failing whisper installation
- update docs and changelog

## Testing
- `pip install numpy Flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860b5eecdd083319797d551ef2f03bb