### PR TITLE
Convert videos to WAV before Whisper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.19] - 07-02-2025
+### Added
+- Helper `convert_to_wav` converts videos to mono 16kHz WAV using ffmpeg.
+- Transcription now converts videos to WAV before invoking Whisper.
+- Unit tests patch `convert_to_wav`.
+- README notes ffmpeg as a required dependency.
+
 ## [0.1.18] - 07-01-2025
 ### Added
 - `--log-level` flag to control logging verbosity.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Run the pipeline (mount the working directory so results persist):
 #### Dependencies
 - Python 3.x
 - `yt-dlp`
+- `ffmpeg` (required for audio conversion and video processing)
 - `whisper.cpp` (required for `--transcribe`)
 - `sentence-transformers`
 - `transformers`

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -159,9 +159,15 @@ def test_transcribe_videos_once(tmp_path, monkeypatch):
     model_file = tmp_path / "models" / "ggml-base.en.bin"
     model_file.parent.mkdir(parents=True, exist_ok=True)
     model_file.write_text("model")
+    def fake_convert(_src, dst):
+        Path(dst).write_bytes(b"wav")
+        return dst
+
     with mock.patch(
         "contradiction_clipper.subprocess.run", side_effect=fake_run
-    ) as mock_run:
+    ) as mock_run, mock.patch(
+        "contradiction_clipper.convert_to_wav", side_effect=fake_convert
+    ):
         cc.transcribe_videos(conn, whisper_bin=str(whisper_bin))
         cc.transcribe_videos(conn, whisper_bin=str(whisper_bin))
         assert mock_run.call_count == 1
@@ -204,9 +210,15 @@ def test_transcribe_parallel_once(tmp_path, monkeypatch):
     model_file = tmp_path / "models" / "ggml-base.en.bin"
     model_file.parent.mkdir(parents=True, exist_ok=True)
     model_file.write_text("model")
+    def fake_convert(_src, dst):
+        Path(dst).write_bytes(b"wav")
+        return dst
+
     with mock.patch(
         "contradiction_clipper.subprocess.run", side_effect=fake_run
-    ) as mock_run:
+    ) as mock_run, mock.patch(
+        "contradiction_clipper.convert_to_wav", side_effect=fake_convert
+    ):
         cc.transcribe_videos(conn, whisper_bin=str(whisper_bin), max_workers=2)
         cc.transcribe_videos(conn, whisper_bin=str(whisper_bin), max_workers=2)
         assert mock_run.call_count == 1


### PR DESCRIPTION
## Summary
- add `convert_to_wav` helper using ffmpeg
- call `convert_to_wav` in `transcribe_videos` and clean up temporary WAVs
- update tests for the new helper
- document ffmpeg requirement
- note changes in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860c42efbe083319cce162742f123bb