### PR TITLE
Fix Whisper build on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Run the pipeline (mount the working directory so results persist):
         # If the binary lives elsewhere, pass its path via --whisper-bin
         # If you skip this step, the pipeline will automatically run the
         # script when transcription is requested.
+        # On macOS the script builds with Metal support and disables
+        # unsupported ARM instructions automatically.
 
 Docker users may skip Steps 2 and 3 after building the image because it installs
 dependencies and runs `install_whisper.sh` automatically.

--- a/build_whisper.sh
+++ b/build_whisper.sh
@@ -18,7 +18,14 @@ if command -v nvidia-smi >/dev/null 2>&1; then
 else
     echo "[i] Building with FFmpeg support."
 fi
-make $MAKE_FLAGS
+
+# macOS requires explicit flags to avoid unsupported ARM instructions
+if [[ "$(uname)" == "Darwin" ]]; then
+    CMAKE_ARGS="-DGGML_METAL=ON -DGGML_METAL_USE_BF16=ON -DGGML_METAL_EMBED_LIBRARY=ON -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a -DCMAKE_OSX_ARCHITECTURES=$(uname -m)"
+    make $MAKE_FLAGS CMAKE_ARGS="$CMAKE_ARGS"
+else
+    make $MAKE_FLAGS
+fi
 
 echo "[i] Copying binary"
 cp ./build/bin/whisper-cli "$ROOT_DIR/whisper"

--- a/install_whisper.sh
+++ b/install_whisper.sh
@@ -25,7 +25,12 @@ else
 fi
 
 echo "[i] Building whisper.cpp"
-make $MAKE_FLAGS
+if [[ "$(uname)" == "Darwin" ]]; then
+    CMAKE_ARGS="-DGGML_METAL=ON -DGGML_METAL_USE_BF16=ON -DGGML_METAL_EMBED_LIBRARY=ON -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a -DCMAKE_OSX_ARCHITECTURES=$(uname -m)"
+    make $MAKE_FLAGS CMAKE_ARGS="$CMAKE_ARGS"
+else
+    make $MAKE_FLAGS
+fi
 
 echo "[i] Moving binary to $WHISPER_BIN"
 cp ./build/bin/whisper-cli "$WHISPER_BIN"


### PR DESCRIPTION
## Summary
- support macOS in `build_whisper.sh` and `install_whisper.sh`
- document macOS handling in README

## Testing
- `pip install numpy Flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68617c1cd2f88331a459eab546123f99